### PR TITLE
标题容器部分的CSS调整

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -40,14 +40,6 @@ body {
 }
 
 @media (max-width: 768px) {
-  .container {
-    flex-direction: column;
-    padding: 10px;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-around;
-  }
-
   .button {
     font-size: 14px;
   }


### PR DESCRIPTION
修改了标题栏的CSS。

这段CSS看来是多余的，它并不会带来实质性的改变。在宽度过小的移动端上甚至会被强制换行（如下图，测试设备为 `iPhone SE`）
![image](https://github.com/user-attachments/assets/fae3eef1-c7f3-47bd-9f66-c8caabd327e8)

修改后，至少显示不至于被折行：
![image](https://github.com/user-attachments/assets/02a80808-2a47-4887-9d78-9ed46efc38c8)

我还建议使用教程按钮直接用 `<a>` 标签实现，或者做成 FAB，悬浮在右下角。